### PR TITLE
Init plugins for first zone in block only

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -648,6 +648,11 @@ func executeDirectives(inst *Instance, filename string,
 						ServerBlockStorage:  storages[i][dir],
 					}
 
+					// only set up directives for the first key in a block
+					if j > 0 {
+						continue
+					}
+
 					setup, err := DirectiveAction(inst.serverType, dir)
 					if err != nil {
 						return err


### PR DESCRIPTION

This implements the caddy change described in coredns/coredns#4593

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>