### PR TITLE
persist config digest on caddy instance

### DIFF
--- a/caddy.go
+++ b/caddy.go
@@ -1048,7 +1048,6 @@ func ConfigDigest(cdyfile Input) ([64]byte, error) {
 	if err != nil {
 		return [64]byte{}, err
 	}
-
 	sblocksJson, err := json.Marshal(sblocks)
 	if err != nil {
 		return [64]byte{}, err

--- a/plugins.go
+++ b/plugins.go
@@ -271,6 +271,15 @@ func RegisterEventHook(name string, hook EventHook) {
 	}
 }
 
+// RegisterOrUpdateEventHook plugs in hook. All the hooks should register themselves
+// and they must have a name.
+func RegisterOrUpdateEventHook(name string, hook EventHook) {
+	if name == "" {
+		panic("event hook must have a name")
+	}
+	eventHooks.Store(name, hook)
+}
+
 // EmitEvent executes the different hooks passing the EventType as an
 // argument. This is a blocking function. Hook developers should
 // use 'go' keyword if they don't want to block Caddy.


### PR DESCRIPTION
This is related to https://github.com/coredns/coredns/issues/6243 and https://github.com/coredns/coredns/issues/6263, and prerequisite for https://github.com/coredns/coredns/pull/6244.

What does this PR do:
1. Enhance `caddy.Instance` with a new field `ConfigDigest`, and populate this with a digest of the parsed configuration content (which then includes imported sources); this happens in `caddy.ValidateAndExecuteDirectives()`. In addition, a function `caddy.ConfigDigest()` is added to allow consumers (such as the coredns reload plugin) to calculate that digest value for a given `caddy.Input`.
2. Add a function `plugin.RegisterOrUpdateEventHook()` which works like the existing `plugin.RegisterEventHook()`, but does not panic in case of duplicate registration (instead, just replaces the hook).

Note: these two changes are independent from each other, but both are required for the mentioned PR  https://github.com/coredns/coredns/pull/6244.