### PR TITLE
fix(caddyfile): bump expansion limits

### DIFF
--- a/caddyfile/parse.go
+++ b/caddyfile/parse.go
@@ -60,7 +60,12 @@ type parser struct {
 }
 
 // maxSnippetExpansions is a hard cap to prevent excessively deep or cyclic snippet imports.
-const maxSnippetExpansions = 1000
+// set as a variable to allow modifications for testing
+var maxSnippetExpansions = 10000
+
+// maxFileExpansions is a hard cap to prevent excessively deep or cyclic file imports.
+// set as a variable to allow modifications for testing
+var maxFileExpansions = 100000
 
 func (p *parser) parseAll() ([]ServerBlock, error) {
 	var blocks []ServerBlock
@@ -268,7 +273,7 @@ func (p *parser) doImport() error {
 		p.snippetExpansions++
 		importedTokens = p.definedSnippets[importPattern]
 	} else {
-		if p.fileExpansions >= maxSnippetExpansions {
+		if p.fileExpansions >= maxFileExpansions {
 			return p.Errf("maximum file import depth (%d) exceeded", maxSnippetExpansions)
 		}
 		p.fileExpansions++


### PR DESCRIPTION
Continues from #8 after I did some testing.

A single `maxSnippetExpansions` of 1000 could be too low for some real world scenarios. Snippet-based configuration can be used broadly across large CoreDNS Corefiles. We cannot implement a pure “import depth” integer with the current splice-then-continue parser - simply because imports are expanded by lexing and splicing tokens into the stream, not by recursive function calls.

Instead, we introduce high default per-directive caps for snippet and file imports, keeping globs counted as one. Prevent trivial snippet self-import. Add tests that lower caps to validate failure on cycles and success with large glob imports.

This should present a generous enough middleground, instead of rewriting the parser.

cc: @miekg @yongtang 