### PR TITLE
fix(caddyfile): prevent NextBlock() infinite loop

### DIFF
--- a/caddyfile/dispenser.go
+++ b/caddyfile/dispenser.go
@@ -111,7 +111,9 @@ func (d *Dispenser) NextLine() bool {
 // not supported.
 func (d *Dispenser) NextBlock() bool {
 	if d.nesting > 0 {
-		d.Next()
+		if !d.Next() {
+			return false
+		}
 		if d.Val() == "}" {
 			d.nesting--
 			return false
@@ -125,7 +127,9 @@ func (d *Dispenser) NextBlock() bool {
 		d.cursor-- // roll back if not opening brace
 		return false
 	}
-	d.Next()
+	if !d.Next() {
+		return false
+	}
 	if d.Val() == "}" {
 		// Open and then closed right away
 		return false


### PR DESCRIPTION
`NextBlock()` now checks the result of `Next()` and stops when EOF is reached. This ensures the cursor always makes forward progress, eliminating a potential infinite loop when a block is unclosed.

Added a test to assert an unclosed block cannot cause `NextBlock()` to return the same token all over again.

This relates to an [OSS-Fuzz finding #446778634](https://issues.oss-fuzz.com/issues/446778634).