### PR TITLE
Fix handling multiple levels of nested blocks

### DIFF
--- a/caddyfile/dispenser.go
+++ b/caddyfile/dispenser.go
@@ -114,7 +114,7 @@ func (d *Dispenser) NextBlock() bool {
 		if !d.Next() {
 			return false
 		}
-		
+
 		if d.Val() == "{" {
 			// a new block, we move the cursor back and try new block flow
 			d.cursor--

--- a/caddyfile/dispenser.go
+++ b/caddyfile/dispenser.go
@@ -114,11 +114,17 @@ func (d *Dispenser) NextBlock() bool {
 		if !d.Next() {
 			return false
 		}
-		if d.Val() == "}" {
-			d.nesting--
-			return false
+		
+		if d.Val() == "{" {
+			// a new block, we move the cursor back and try new block flow
+			d.cursor--
+		} else {
+			if d.Val() == "}" {
+				d.nesting--
+				return false
+			}
+			return true
 		}
-		return true
 	}
 	if !d.NextArg() { // block must open on same line
 		return false

--- a/caddyfile/dispenser.go
+++ b/caddyfile/dispenser.go
@@ -107,8 +107,7 @@ func (d *Dispenser) NextLine() bool {
 // to load the next token as long as it opens a block or
 // is already in a block. It returns true if a token was
 // loaded, or false when the block's closing curly brace
-// was loaded and thus the block ended. Nested blocks are
-// not supported.
+// was loaded and thus the block ended.
 func (d *Dispenser) NextBlock() bool {
 	if d.nesting > 0 {
 		if !d.Next() {

--- a/caddyfile/dispenser_test.go
+++ b/caddyfile/dispenser_test.go
@@ -200,12 +200,12 @@ func TestDispenser_NextBlock_MakesProgressOrStopsOnEOF(t *testing.T) {
 
 func TestDispenser_NextBlock_MultipleLevelsOfNestedBlocks(t *testing.T) {
 	input := `foobar1 {
-			  	sub1 arg1
-			  	sub2
-			  	sub_foobar1 sub_foobar1_arg {
-					sub3 arg3
-					sub4
-			  	}
+			    sub1 arg1
+			    sub2
+			    sub_foobar1 sub_foobar1_arg {
+			      sub3 arg3
+			      sub4
+			    }
 			  }
 			  foobar2 {
 			  }`


### PR DESCRIPTION
When parsing something like:

```caddyfile
foobar1 {
    sub1 arg1
    sub2
    sub_foobar1 sub_foobar1_arg {
        sub3 arg3
        sub4
    }
}

foobar2 {
}
```

I noticed a strange issue:

- Calling Next() on sub_foobar1 works fine — I correctly get sub_foobar1_arg.
- But right after that, calling NextBlock() and then Val() gives me… {.

What I actually expect there is sub3.

**Changes**:

When nesting > 0, if the next token is {, it means we've entered a new block.
So we move the cursor back and continue with the same logic as when nesting == 0 in old code.

Now NextBlock() correctly steps into the nested block and Val() returns the expected first item (sub3).